### PR TITLE
Dropdown menu added to highlight nodes

### DIFF
--- a/R/edgebundleR.R
+++ b/R/edgebundleR.R
@@ -21,6 +21,16 @@
 #'   this argument.  Default: c(5,20).
 #' @param directed whether or not the graph is directed. Does not work yet.
 #'   Need to think about how to implement this cleanly.
+#' @param selectNodeAction enables users to write own Javascript and evaluate it when
+#' node is selected. Inspired from visNetwork::visEvents(selectNode).
+#' @param mouseoverAction enables users to write own Javascript and evaluate it when
+#' node is hovered over by mouse. Inspired from visNetwork::visEvents(hoverNode).
+#' @param mouseoutAction enables users to write own Javascript and evaluate it when
+#' node is no longer being hovered over by mouse. Inspired from visNetwork::visEvents(blurNode).
+#' @param deselectNodeAction enables users to write own Javascript and evaluate it when
+#' node is deselected. Inspired from visNetwork::visEvents(deselectNode).
+#' @param dropdownVar variable for dropdown menu when using an igraph object. Dropdown
+#' menu selection highlights a group of nodes of interest.
 #'
 #' @import htmlwidgets
 #' @import rjson
@@ -40,11 +50,16 @@ edgebundle <- function(x, tension=0.5, cutoff=0.1, width = NULL,
                        selectNodeAction = NULL,
                        mouseoverAction = NULL,
                        mouseoutAction = NULL,
-                       deselectNodeAction = NULL) {
+                       deselectNodeAction = NULL,
+                       dropdownVar = NULL) {
   if((typeof(x)=="character")){
     json_data <- rjson::fromJSON(file = x)
     json_real = rjson::toJSON(json_data)
+    dropdownVar = NULL
   } else if (class(x)=="igraph"){
+    if (!is.null(dropdownVar)){
+      igraph::vertex_attr(graph = x, name = 'dropdownVar') <- igraph::get.vertex.attribute(x)[dropdownVar][[dropdownVar]]
+    }
     json_real = edgeToJSON_igraph(x)#d3r::d3_igraph(x)#edgeToJSON_igraph(x)
     directed = is.directed(x)
   } else {
@@ -57,6 +72,7 @@ edgebundle <- function(x, tension=0.5, cutoff=0.1, width = NULL,
     adj = corX>cutoff
     edges = adjToEdge(adj)
     json_real = edgeToJSON_matrix(edges)
+    dropdownVar = NULL
   }
   height=width
   # forward options using x
@@ -72,7 +88,8 @@ edgebundle <- function(x, tension=0.5, cutoff=0.1, width = NULL,
     selectNodeAction = selectNodeAction,
     mouseoverAction = mouseoverAction,
     mouseoutAction = mouseoutAction,
-    deselectNodeAction = deselectNodeAction
+    deselectNodeAction = deselectNodeAction,
+    dropdownVar = dropdownVar
   )
   # create widget
   htmlwidgets::createWidget(

--- a/vignettes/edgebundleR.Rmd
+++ b/vignettes/edgebundleR.Rmd
@@ -247,7 +247,8 @@ server <- function(input, output) {
                 selectNodeAction = "Shiny.onInputChange('select_node_id', d.key);",
                 deselectNodeAction =  "Shiny.onInputChange('select_node_id', 'Node_deselected');",
                 mouseoverAction = "Shiny.onInputChange('hover_node_id', d.name);",
-                mouseoutAction = "Shiny.onInputChange('hover_node_id', 'Not_Currently_Hovering');")
+                mouseoutAction = "Shiny.onInputChange('hover_node_id', 'Not_Currently_Hovering');",
+                dropdownVar = 'Loc'))
   })
   output$text1 <- renderPrint({ paste0('Selection: ', input$select_node_id) })
   output$text2 <- renderPrint({ paste0('mouseover: ', input$hover_node_id) })
@@ -262,6 +263,7 @@ ui <- fluidPage(
 
 shinyApp(ui = ui, server = server)
 ```
+Please note that the `dropdownVar` functionality, which enables the use of a drop down menu to highlight groups of variables, is currently only available for `igraph` objects.
 
 ## Saving and sharing
 

--- a/vignettes/edgebundleR.Rmd
+++ b/vignettes/edgebundleR.Rmd
@@ -248,7 +248,7 @@ server <- function(input, output) {
                 deselectNodeAction =  "Shiny.onInputChange('select_node_id', 'Node_deselected');",
                 mouseoverAction = "Shiny.onInputChange('hover_node_id', d.name);",
                 mouseoutAction = "Shiny.onInputChange('hover_node_id', 'Not_Currently_Hovering');",
-                dropdownVar = 'Loc'))
+                dropdownVar = 'Loc')
   })
   output$text1 <- renderPrint({ paste0('Selection: ', input$select_node_id) })
   output$text2 <- renderPrint({ paste0('mouseover: ', input$hover_node_id) })


### PR DESCRIPTION
I added a dropdown menu that highlights groups of nodes. The hover/select options remain functional while the nodes are highlighted. This works only for the igraph objects that are uploaded. The image below shows how you can highlight 'Group 3'. Thought this might be useful if there are several groups.

Three files modified: the vignette (edgebundleR.Rmd), the javascript (edgebundleR.js), and the R call (edgebundleR.R).

![dropdown_illustration](https://user-images.githubusercontent.com/52332666/219695933-1756184b-59f6-4124-b9f7-5085fc8e35db.png)
